### PR TITLE
refactor: extract chart controls styles

### DIFF
--- a/src/components/ChartControls.css
+++ b/src/components/ChartControls.css
@@ -1,0 +1,11 @@
+/* src/components/ChartControls.css */
+
+.chart-controls-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+  width: 100%;
+}
+

--- a/src/components/ChartControls.tsx
+++ b/src/components/ChartControls.tsx
@@ -5,6 +5,7 @@ import {
   IonLabel,
 } from '@ionic/react';
 import { IonSegmentCustomEvent, SegmentChangeEventDetail } from '@ionic/core';
+import './ChartControls.css';
 
 interface YearOption {
   value: number;
@@ -28,15 +29,9 @@ const ChartControls: React.FC<ChartControlsProps> = ({
 }) => {
 
   return (
-    <div style={{
-        display: 'flex',
-        justifyContent: 'center',
-        alignItems: 'center',
-        gap: '16px',
-        flexWrap: 'wrap',
-        width: '100%'
-        }}>
+    <div className="chart-controls-container">
         <IonSegment
+          aria-label="Anzeigeintervall"
           value={viewMode}
           onIonChange={(e: IonSegmentCustomEvent<SegmentChangeEventDetail>) => onViewModeChange(e.detail.value as 'annual' | 'quarterly' | undefined)}
         >
@@ -49,6 +44,7 @@ const ChartControls: React.FC<ChartControlsProps> = ({
         </IonSegment>
 
         <IonSegment
+          aria-label="Zeitraum"
           value={displayYears.toString()}
           onIonChange={(e: IonSegmentCustomEvent<SegmentChangeEventDetail>) => onYearsChange(e.detail.value?.toString())}
         >


### PR DESCRIPTION
## Summary
- extract ChartControls layout styles into dedicated stylesheet
- add aria labels for IonSegment controls

## Testing
- `npm test` (fails: Missing script "test")
- `npm run test.unit`
- `npm run lint` (fails: 22 errors)

------
https://chatgpt.com/codex/tasks/task_e_689a4c8c39308333a6b09d1d06b65c04