### PR TITLE
fix: cast segment value to string

### DIFF
--- a/src/components/MetricSwitcher.tsx
+++ b/src/components/MetricSwitcher.tsx
@@ -18,7 +18,7 @@ interface MetricSwitcherProps {
 const MetricSwitcher: React.FC<MetricSwitcherProps> = ({ options, selectedValue, onSelectionChange }) => {
   const handleChange = (e: IonSegmentCustomEvent<SegmentChangeEventDetail>) => {
     if (e.detail.value) {
-      onSelectionChange(e.detail.value);
+      onSelectionChange(e.detail.value as string);
     }
   };
 


### PR DESCRIPTION
## Summary
- cast segment change event value to string before invoking callback

## Testing
- `npm run test.unit`
- `npm run lint` *(fails: Unexpected any in multiple utils files)*

------
https://chatgpt.com/codex/tasks/task_e_689fa85648cc833382af8377c6339c1c