### PR TITLE
chore: remove unused FcfMetricType import

### DIFF
--- a/src/components/ChartGrid.tsx
+++ b/src/components/ChartGrid.tsx
@@ -8,7 +8,6 @@ import {
 import { expandOutline } from 'ionicons/icons';
 import BarChart from './BarChart';
 import { MultiDatasetStockData } from '../types/stockDataTypes';
-import { FcfMetricType } from '../pages/Home';
 
 interface ModalChartConfig {
   title: string;


### PR DESCRIPTION
## Summary
- remove unused `FcfMetricType` import from ChartGrid component

## Testing
- `npm run lint` (fails: Unexpected any @typescript-eslint/no-explicit-any)
- `npm run test.unit -- --run`
- `npm run test.e2e` (fails: missing Xvfb)


------
https://chatgpt.com/codex/tasks/task_e_689fa9752aac8333b985e178f1a2e922