### PR TITLE
Add ROE and ROA metrics to key stats dashboard

### DIFF
--- a/src/components/KeyStatsDashboard.tsx
+++ b/src/components/KeyStatsDashboard.tsx
@@ -67,6 +67,8 @@ const KeyStatsDashboard: React.FC<KeyStatsDashboardProps> = ({
             <h2 className="stats-title">Margins & Growth</h2>
             <IonItem lines="none"><IonLabel>Profit Margin</IonLabel><IonNote slot="end">{keyMetrics?.grossMargin ?? 'N/A'}</IonNote></IonItem>
             <IonItem lines="none"><IonLabel>Operating Margin</IonLabel><IonNote slot="end">{keyMetrics?.operatingMargin ?? 'N/A'}</IonNote></IonItem>
+            <IonItem lines="none"><IonLabel>Return on Equity</IonLabel><IonNote slot="end">{keyMetrics?.returnOnEquity ?? 'N/A'}</IonNote></IonItem>
+            <IonItem lines="none"><IonLabel>Return on Assets</IonLabel><IonNote slot="end">{keyMetrics?.returnOnAssets ?? 'N/A'}</IonNote></IonItem>
           </IonCol>
 
           <IonCol size="12" size-md="3" className="stats-col">

--- a/src/types/stockDataTypes.ts
+++ b/src/types/stockDataTypes.ts
@@ -41,6 +41,8 @@ export interface KeyMetrics {
   isPositiveChange: boolean;
   grossMargin: string | null;
   operatingMargin: string | null;
+  returnOnEquity: string | null;
+  returnOnAssets: string | null;
   payoutRatio: string | null;
   payoutDate: string | null;
   freeCashFlowYield: string | null;

--- a/src/utils/stockDataProcessing.ts
+++ b/src/utils/stockDataProcessing.ts
@@ -130,6 +130,8 @@ export const processStockData = (rawData: RawApiData, ticker: string): Processed
       isPositiveChange: !isNaN(numChange) && numChange >= 0,
       grossMargin: formatMarginForDisplay(incomeProcessed.latestAnnualGrossMargin),
       operatingMargin: formatMarginForDisplay(incomeProcessed.latestAnnualOperatingMargin),
+      returnOnEquity: formatPercentage(overview?.ReturnOnEquityTTM),
+      returnOnAssets: formatPercentage(overview?.ReturnOnAssetsTTM),
       payoutRatio: formatPercentage(overview?.PayoutRatio),
       payoutDate: overview?.DividendDate || 'N/A',
       freeCashFlowYield: formatPercentage(fcfYield),


### PR DESCRIPTION
## Summary
- track Return on Equity and Return on Assets in key metrics
- display ROE and ROA in the Margins & Growth section of the dashboard

## Testing
- `npm run lint` *(fails: Unexpected any in existing files)*
- `npm run test.unit`


------
https://chatgpt.com/codex/tasks/task_e_689fad7b70b48333b6d3f91cbf64ef7e