### PR TITLE
fix: allow KeyStats labels to wrap

### DIFF
--- a/src/components/KeyStatsDashboard.css
+++ b/src/components/KeyStatsDashboard.css
@@ -112,21 +112,20 @@
   font-size: 0.85rem;
 }
 
-/* --- HIER IST DIE ÄNDERUNG --- */
-.stats-grid ion-label {
+ .stats-grid ion-label {
   color: var(--text-color-muted);
-  flex: 0 1 auto; /* Nimmt nur den Platz ein, den es braucht */
-  white-space: nowrap; /* Verhindert den Zeilenumbruch */
-  margin-right: 16px; /* Fügt Abstand zum Wert hinzu */
-}
-
-.stats-grid ion-note {
+  flex: 1 1 auto;
+  white-space: normal;
+  margin-right: 16px; /* Space between label and value */
+ }
+ 
+ .stats-grid ion-note {
   color: var(--text-color-default);
   font-weight: 500;
-  flex: 1 1 0%; /* Nimmt den restlichen verfügbaren Platz ein */
+  flex: 0 0 auto;
   text-align: right;
-  justify-content: flex-end; /* Stellt sicher, dass der Inhalt rechtsbündig ist */
-}
+  justify-content: flex-end; /* Ensure content is right-aligned */
+ }
 
 .stats-grid .address-note {
     white-space: normal; /* Erlaube Zeilenumbruch für die Adresse */


### PR DESCRIPTION
## Summary
- allow labels in KeyStatsDashboard to wrap and use remaining space
- prevent notes from shrinking labels by fixing flex sizing

## Testing
- `npm run lint` *(fails: Unexpected any. Specify a different type)*
- `npm run test.unit -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a389d9b540833384246e084fa65cd2