### PR TITLE
feat: add price to fcf ratio chart

### DIFF
--- a/src/components/ChartGrid.tsx
+++ b/src/components/ChartGrid.tsx
@@ -30,13 +30,15 @@ interface ChartGridProps {
   dpsData: MultiDatasetStockData;
   onExpandChart: (chartId: string, config: ModalChartConfig) => void;
   fcfAbsData: MultiDatasetStockData;
+  priceToFcfData: MultiDatasetStockData;
 }
 
 const ChartGrid: React.FC<ChartGridProps> = ({
   loading, viewMode, incomeData, cashflowData, marginsData, epsData,
   sharesData, debtToEquityData, paysDividends, totalDividendsData, dpsData,
   onExpandChart,
-  fcfAbsData
+  fcfAbsData,
+  priceToFcfData
 }) => {
   const chartViewModeLabel = viewMode === 'annual' ? 'Annual' : 'Quarterly';
 
@@ -50,6 +52,7 @@ const ChartGrid: React.FC<ChartGridProps> = ({
     totalDividends: { chartId: 'totalDividends', title: `Total Dividends Paid (${chartViewModeLabel})`, yAxisFormat: 'currency', yAxisLabel: 'Billions ($B)' } as ModalChartConfig,
     dps: { chartId: 'dps', title: `Dividend Per Share (${chartViewModeLabel})`, yAxisFormat: 'number', yAxisLabel: 'DPS ($)' } as ModalChartConfig,
     fcf: { chartId: 'fcf', title: `Free Cash Flow (${chartViewModeLabel})`, yAxisFormat: 'currency', yAxisLabel: 'Billions ($B)' } as ModalChartConfig,
+    pfcf: { chartId: 'pfcf', title: `Price/FCF (${chartViewModeLabel})`, yAxisFormat: 'ratio', yAxisLabel: 'P/FCF Ratio' } as ModalChartConfig,
   };
 
   const canShowTotalDividends = paysDividends && totalDividendsData?.labels?.length > 0 && totalDividendsData.datasets[0]?.values?.length > 0;
@@ -98,7 +101,24 @@ const ChartGrid: React.FC<ChartGridProps> = ({
           </IonCard>
         </IonCol>
       </IonRow>
-      
+
+      <IonRow>
+        <IonCol size="12">
+          <IonCard className="chart-grid-card">
+            <IonCardHeader>
+              {renderHeaderContent(chartConfigs.pfcf.title, () => onExpandChart('pfcf', chartConfigs.pfcf))}
+            </IonCardHeader>
+            <IonCardContent>
+              {priceToFcfData?.labels?.length > 0 && priceToFcfData.datasets[0]?.values?.length > 0 ? (
+                <div className="chart-wrapper-div">
+                  <BarChart data={priceToFcfData} title={chartConfigs.pfcf.title} yAxisFormat={chartConfigs.pfcf.yAxisFormat} yAxisLabel={chartConfigs.pfcf.yAxisLabel} />
+                </div>
+              ) : !loading && (<p>Keine P/FCF Daten verfügbar.</p>)}
+            </IonCardContent>
+          </IonCard>
+        </IonCol>
+      </IonRow>
+
       <IonRow>
         <IonCol size="12" size-lg="6">
            <IonCard className="chart-grid-card">

--- a/src/hooks/useStockData.ts
+++ b/src/hooks/useStockData.ts
@@ -44,6 +44,8 @@ export const useStockData = (): UseStockDataResult => {
   const [quarterlyFCF, setQuarterlyFCF] = useState<StockData>(initialStockData);
   const [annualFCFPerShare, setAnnualFCFPerShare] = useState<StockData>(initialStockData);
   const [quarterlyFCFPerShare, setQuarterlyFCFPerShare] = useState<StockData>(initialStockData);
+  const [annualPriceToFcf, setAnnualPriceToFcf] = useState<StockData>(initialStockData);
+  const [quarterlyPriceToFcf, setQuarterlyPriceToFcf] = useState<StockData>(initialStockData);
 
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -85,6 +87,8 @@ export const useStockData = (): UseStockDataResult => {
       setQuarterlyFCF(cached.quarterlyFCF);
       setAnnualFCFPerShare(cached.annualFCFPerShare);
       setQuarterlyFCFPerShare(cached.quarterlyFCFPerShare);
+      setAnnualPriceToFcf(cached.annualPriceToFcf);
+      setQuarterlyPriceToFcf(cached.quarterlyPriceToFcf);
       return;
     }
 
@@ -118,6 +122,8 @@ export const useStockData = (): UseStockDataResult => {
     setQuarterlyFCF(initialStockData);
     setAnnualFCFPerShare(initialStockData);
     setQuarterlyFCFPerShare(initialStockData);
+    setAnnualPriceToFcf(initialStockData);
+    setQuarterlyPriceToFcf(initialStockData);
 
     try {
       setProgress(10);
@@ -153,6 +159,8 @@ export const useStockData = (): UseStockDataResult => {
       setQuarterlyFCF(processedData.quarterlyFCF);
       setAnnualFCFPerShare(processedData.annualFCFPerShare);
       setQuarterlyFCFPerShare(processedData.quarterlyFCFPerShare);
+      setAnnualPriceToFcf(processedData.annualPriceToFcf);
+      setQuarterlyPriceToFcf(processedData.quarterlyPriceToFcf);
       
       setCachedData(prevCache => ({ ...prevCache, [ticker]: processedData }));
       
@@ -179,5 +187,7 @@ export const useStockData = (): UseStockDataResult => {
     quarterlyFCF,
     annualFCFPerShare,
     quarterlyFCFPerShare,
+    annualPriceToFcf,
+    quarterlyPriceToFcf,
   };
 };

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -45,6 +45,7 @@ const Home: React.FC = () => {
     annualDPS, quarterlyDPS,
     annualFCF, quarterlyFCF,
     annualFCFPerShare, quarterlyFCFPerShare,
+    annualPriceToFcf, quarterlyPriceToFcf,
     paysDividends, balanceSheetMetrics,
     loading, error, progress, companyInfo, keyMetrics, fetchData
   } = useStockData();
@@ -76,6 +77,7 @@ const Home: React.FC = () => {
   const dpsData = sliceMultiDataToLastNPoints(toMulti(viewMode === 'annual' ? annualDPS : quarterlyDPS, 'DPS ($)'), pointsToKeep);
   const fcfAbsData = sliceMultiDataToLastNPoints(toMulti(viewMode === 'annual' ? annualFCF : quarterlyFCF, 'Free Cash Flow ($B)'), pointsToKeep);
   const fcfPerShareData = sliceMultiDataToLastNPoints(toMulti(viewMode === 'annual' ? annualFCFPerShare : quarterlyFCFPerShare, 'FCF per Share ($)'), pointsToKeep);
+  const priceToFcfData = sliceMultiDataToLastNPoints(toMulti(viewMode === 'annual' ? annualPriceToFcf : quarterlyPriceToFcf, 'P/FCF'), pointsToKeep);
 
   const handleSearch = (query: string) => { setCurrentTicker(query.toUpperCase()); };
   // ... (restliche Handler bleiben gleich)
@@ -201,6 +203,7 @@ const Home: React.FC = () => {
                        totalDividendsData={totalDividendsData}
                        dpsData={dpsData}
                        fcfAbsData={fcfAbsData}
+                       priceToFcfData={priceToFcfData}
                        onExpandChart={openChartModal}
                     />
                  </>
@@ -225,6 +228,7 @@ const Home: React.FC = () => {
             dps: dpsData,
             fcf: fcfAbsData,
             fcfPerShare: fcfPerShareData,
+            pfcf: priceToFcfData,
           }}
         />
       </IonContent>

--- a/src/types/stockDataTypes.ts
+++ b/src/types/stockDataTypes.ts
@@ -73,6 +73,8 @@ export interface UseStockDataResult {
   quarterlyFCF: StockData;
   annualFCFPerShare: StockData;
   quarterlyFCFPerShare: StockData;
+  annualPriceToFcf: StockData;
+  quarterlyPriceToFcf: StockData;
   // --- ENDE FCF KENNZAHLEN ---
 
   balanceSheetMetrics: BalanceSheetMetrics | null;

--- a/src/utils/stockDataProcessing.ts
+++ b/src/utils/stockDataProcessing.ts
@@ -119,6 +119,15 @@ export const processStockData = (rawData: RawApiData, ticker: string): Processed
   const annualFCFPerShare = divideStockDataPerShare(cashflowProcessed.annualFCF, balanceSheetProcessed.annualSharesOutstanding);
   const quarterlyFCFPerShare = divideStockDataPerShare(cashflowProcessed.quarterlyFCF, balanceSheetProcessed.quarterlySharesOutstanding);
 
+  const calcPriceToFcf = (fcfData: StockData, mc: number): StockData => {
+    const labels = fcfData.labels;
+    const values = fcfData.values.map(v => (v !== 0 ? mc / (v * 1e9) : 0));
+    return { labels, values };
+  };
+
+  const annualPriceToFcf = calcPriceToFcf(cashflowProcessed.annualFCF, marketCap);
+  const quarterlyPriceToFcf = calcPriceToFcf(cashflowProcessed.quarterlyFCF, marketCap);
+
   const keyMetrics: KeyMetrics = {
       peRatio: formatMetric(overview?.PERatio),
       psRatio: formatMetric(overview?.PriceToSalesRatioTTM),
@@ -166,5 +175,7 @@ export const processStockData = (rawData: RawApiData, ticker: string): Processed
     quarterlyFCF: cashflowProcessed.quarterlyFCF,
     annualFCFPerShare,
     quarterlyFCFPerShare,
+    annualPriceToFcf,
+    quarterlyPriceToFcf,
   };
 };


### PR DESCRIPTION
## Summary
- add annual/quarterly price-to-FCF fields to stock data types
- compute price-to-FCF ratios from market cap and cash flow
- display Price/FCF chart in dashboard

## Testing
- `npm run lint` *(fails: Unexpected any, existing code)*
- `npm run test.unit`


------
https://chatgpt.com/codex/tasks/task_e_68a38cddf5048333b355ee143acde5b8